### PR TITLE
Add more checks if file exists before deleting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "ch.tyderion"
-version = "4.0.2"
+version = "4.0.3"
 
 java {
     targetCompatibility = JavaVersion.VERSION_21

--- a/src/main/java/processing/FileHandler.java
+++ b/src/main/java/processing/FileHandler.java
@@ -38,7 +38,11 @@ public class FileHandler implements IFileHandler {
         log.fine(STR."Copying file from \{from.toAbsolutePath()} to \{to.toAbsolutePath()}");
         try {
             Files.copy(from, to, StandardCopyOption.COPY_ATTRIBUTES);
-            Files.delete(from);
+            // Even though Files.copy should throw an exception if it fails, we still check if the file was copied correctly
+            if (Files.exists(to) && Files.size(to) == Files.size(from)) {
+                log.fine(STR."Successfully copied file from \{from.toAbsolutePath()} to \{to.toAbsolutePath()}. Deleting original file.");
+                Files.delete(from);
+            }
             return true;
         } catch (IOException e) {
             log.severe(STR."Could not move file from \{from.toAbsolutePath()} to \{to.toAbsolutePath()}: \{e.getMessage()}.");


### PR DESCRIPTION
Even though the copy method should throw if it doesn't complete, we still check if the target file exists and has the same size before we delete the original.