### PR TITLE
Add exit code per picocli docs

### DIFF
--- a/src/main/java/processing/EpisodeProcessing.java
+++ b/src/main/java/processing/EpisodeProcessing.java
@@ -106,6 +106,7 @@ public class EpisodeProcessing implements FileProcessor.Processor {
                 if (fileInfo.hasActionFailed(FileAction.FileCmd)) {
                     // Error, file data not found, skip continuing with dependant steps
                     log.warn(STR."FileCommand for file \{fileInfo.getFile().getAbsolutePath()} with Id \{fileInfo.getId()} failed to get data. Skipping dependant steps");
+                    finalize(fileInfo);
                     return;
                 }
                 if (config.rename().mode() != RenameConfig.Mode.NONE ||

--- a/src/main/java/startup/Main.java
+++ b/src/main/java/startup/Main.java
@@ -10,8 +10,10 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        new picocli.CommandLine(new CliCommand())
+        int exitCode = new picocli.CommandLine(new CliCommand())
                 .setExecutionStrategy(new ConfigValidatingExecutionStrategy())
                 .execute(args);
+
+        System.exit(exitCode);
     }
 }


### PR DESCRIPTION
I noticed while running this on the command line interactively, or via bash/powershell script that the process did not seem to exit cleanly to the shell even after all processing has completed.

Per picocli docs, add an explicit exit with return code.
- https://picocli.info/quick-guide.html#_exit_code

Additionally, when the last file processed triggered fileInfo.hasActionFailed(FileAction.FileCmd), then it would never send the ProcessingEvent.Done event and aniadd would not shutdown.